### PR TITLE
fixes #8882 - raise error if create_discovered_host fails

### DIFF
--- a/lib/smart_proxy_discovery/discovery_main.rb
+++ b/lib/smart_proxy_discovery/discovery_main.rb
@@ -11,8 +11,11 @@ module Proxy::Discovery
 
     def create_discovered_host(request)
       foreman_request = Proxy::HttpRequest::ForemanRequest.new()
-      req = foreman_request.request_factory.create_post(CREATE_DISCOVERED_HOST_PATH, request.body)
-      foreman_request.send_request(req)
+      req = foreman_request.request_factory.create_post(CREATE_DISCOVERED_HOST_PATH, request.body.read)
+      response = foreman_request.send_request(req)
+      unless response.is_a? Net::HTTPSuccess
+        raise response
+      end
     end
 
     def refresh_facts(ip)

--- a/test/discovery_api_test.rb
+++ b/test/discovery_api_test.rb
@@ -31,8 +31,6 @@ class DiscoveryApiTest < Test::Unit::TestCase
   end
 
   def test_create_facts_failure
-    skip "BUG: proxy always return 200 (http://projects.theforeman.org/issues/8882)"
-    # implement failures for all the other requests
     stub_request(:post, "#{@foreman_url}/api/v2/discovered_hosts/facts")
       .to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
     post "/create", @facts
@@ -46,11 +44,25 @@ class DiscoveryApiTest < Test::Unit::TestCase
     assert last_response.successful?
   end
 
+  def test_refresh_facts_failure
+    stub_request(:get, "http://#{@discovered_node}:8443/facts")
+      .to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
+    get "/#{@discovered_node}/facts"
+    assert_equal 500, last_response.status
+  end
+
   def test_reboot_success
     stub_request(:put, "http://#{@discovered_node}:8443/bmc/#{@discovered_node}/chassis/power/cycle")
     put "/#{@discovered_node}/reboot"
     assert_empty last_response.body
     assert last_response.successful?
+  end
+
+  def test_reboot_failure
+    stub_request(:put, "http://#{@discovered_node}:8443/bmc/#{@discovered_node}/chassis/power/cycle")
+      .to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
+    put "/#{@discovered_node}/reboot"
+    assert_equal 500, last_response.status
   end
 
 end


### PR DESCRIPTION
1) Modified on `create_discovered_host` to `request.body.read` or else it will raise `StringIO` error.
2) Checking that the response is in the 20X range of `Net::HTTP` (all the 20X classes inherit from `Net::HTTPSuccess`)
3) failure tests for all the other requests
