### PR TITLE
Fixes #9459 - authorize_with_trusted_hosts disabled

### DIFF
--- a/lib/smart_proxy_discovery/discovery_api.rb
+++ b/lib/smart_proxy_discovery/discovery_api.rb
@@ -6,7 +6,9 @@ module Proxy::Discovery
 
   class Api < ::Sinatra::Base
     helpers ::Proxy::Helpers
-    authorize_with_trusted_hosts
+    # workaround to allow discovered hosts to reach the proxy
+    # http://projects.theforeman.org/issues/9460
+    #authorize_with_trusted_hosts
 
     post '/create' do
       content_type :json


### PR DESCRIPTION
We need to disable authorize_with_trusted_hosts because otherwise discovered
hosts cannot reach proxy (they have not proper DNS setup yet). This is a
workaround because it opens up possibility to reboot any host via HTTPS via
Proxy.

I am filing new bug to fix this but we will do this in future release properly:
http://projects.theforeman.org/issues/9460

Can you please release new version of the gem? We need to rebase downstream to
get also one additional fix that was not yet released. Thanks.
