### PR TITLE
Refs #9482 - leverage patterns for authorize_with_trusted_hosts

### DIFF
--- a/lib/smart_proxy_discovery/discovery_api.rb
+++ b/lib/smart_proxy_discovery/discovery_api.rb
@@ -6,8 +6,9 @@ module Proxy::Discovery
 
   class Api < ::Sinatra::Base
     helpers ::Proxy::Helpers
-    authorize_with_trusted_hosts
+    authorize_with_trusted_hosts(/\/[^\/]+\/(facts|reboot)/)
 
+    # DISCOVERED HOSTS -> PROXY -> FOREMAN actions (not authorized)
     post '/create' do
       content_type :json
       begin
@@ -17,6 +18,7 @@ module Proxy::Discovery
       end
     end
 
+    # FOREMAN -> PROXY -> DISCOVERED HOSTS actions (authorize_with_trusted_hosts)
     get '/:ip/facts' do
       content_type :json
       begin


### PR DESCRIPTION
Foreman discovery proxy plugin needs to specify for which paths it will
authorize. Since Sinatra supports patters for filters
(http://www.sinatrarb.com/intro.html#Filters) it is relatively easy to
implement this so plugins can take advantage of this. This change will NOT
break the API, by default filters will apply to all paths (nil).

Replaces https://github.com/theforeman/smart_proxy_discovery/pull/5
