### PR TITLE
Fixes #9482 - split sinatra into two apps

### DIFF
--- a/lib/smart_proxy_discovery/http_config.ru
+++ b/lib/smart_proxy_discovery/http_config.ru
@@ -1,5 +1,5 @@
 require 'smart_proxy_discovery/discovery_api'
 
 map '/discovery' do
-  run Proxy::Discovery::Api
+  run Proxy::Discovery::Dispatcher.new
 end

--- a/test/discovery_api_test.rb
+++ b/test/discovery_api_test.rb
@@ -9,7 +9,7 @@ class DiscoveryApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
 
   def app
-    ::Proxy::Discovery::Api.new
+    ::Proxy::Discovery::Dispatcher.new
   end
 
   def setup
@@ -34,6 +34,7 @@ class DiscoveryApiTest < Test::Unit::TestCase
     stub_request(:post, "#{@foreman_url}/api/v2/discovered_hosts/facts").to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
     post "/create", @facts
     assert_equal 500, last_response.status
+    assert_match(/^failed to update Foreman/, last_response.body)
   end
 
   def test_refresh_facts_success
@@ -47,6 +48,7 @@ class DiscoveryApiTest < Test::Unit::TestCase
     stub_request(:get, "http://#{@discovered_node}:8443/facts").to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
     get "/#{@discovered_node}/facts"
     assert_equal 500, last_response.status
+    assert_match(/^failed to update Foreman/, last_response.body)
   end
 
   def test_reboot_success
@@ -60,6 +62,7 @@ class DiscoveryApiTest < Test::Unit::TestCase
     stub_request(:put, "http://#{@discovered_node}:8443/bmc/#{@discovered_node}/chassis/power/cycle").to_return(:body => '{"status": "error", "message": "blah"}', :status => 500)
     put "/#{@discovered_node}/reboot"
     assert_equal 500, last_response.status
+    assert_match(/^failed to update Foreman/, last_response.body)
   end
 
 end


### PR DESCRIPTION
Here is a different approach which is more sane and replaces
https://github.com/theforeman/smart-proxy/pull/260

This is independent of Sinatra version and should work with all Rack versions
as well because it only uses basic Rack Interface. The key concept of this
solution is not to introduce fragile code changes into authorization code and
not to split this plugin into two separate ones.

This allows to keep the `/discovery` namespace for both inbound and outbound
communication while two separate Sinatra apps have different authorization
code.

While for this version we currently do not authorize requests coming from
discovered hosts as they are stateless, the plan for the future is to pass a
SSL client cert via kernel command line and secure this as well. This approach
should allow this quite easily (we need to implement another authorize_
method).
