### PR TITLE
Refs #12003 - new API for refresh_facts action

### DIFF
--- a/lib/smart_proxy_discovery/discovery_api.rb
+++ b/lib/smart_proxy_discovery/discovery_api.rb
@@ -49,10 +49,19 @@ module Proxy::Discovery
     include ApiHelpers
     authorize_with_trusted_hosts
 
+    get '/:ip/inventory/facter' do
+      content_type :json
+      begin
+        Proxy::Discovery.inventory_facter(params[:ip])
+      rescue => error
+        error_responder(error)
+      end
+    end
+
     get '/:ip/facts' do
       content_type :json
       begin
-        Proxy::Discovery.refresh_facts(params[:ip])
+        Proxy::Discovery.refresh_facts_legacy(params[:ip])
       rescue => error
         error_responder(error)
       end

--- a/lib/smart_proxy_discovery/discovery_main.rb
+++ b/lib/smart_proxy_discovery/discovery_main.rb
@@ -8,7 +8,6 @@ module Proxy::Discovery
 
   class << self
     CREATE_DISCOVERED_HOST_PATH = '/api/v2/discovered_hosts/facts'
-    REFRESH_HOST_PATH           = '/facts'
     SCHEME = Proxy::Discovery::Plugin.settings.node_scheme
     PORT = Proxy::Discovery::Plugin.settings.node_port
 
@@ -22,9 +21,14 @@ module Proxy::Discovery
       end
     end
 
-    def refresh_facts(ip)
+    def inventory_facter(ip)
       client = get_rest_client(generate_url(ip))
-      client[REFRESH_HOST_PATH].get
+      client["/inventory/facter"].get()
+    end
+
+    def refresh_facts_legacy(ip)
+      client = get_rest_client(generate_url(ip))
+      client['/facts'].get
     end
 
     def reboot_legacy(ip)


### PR DESCRIPTION
@stbenjam This is the last series of patches. Since fdi 3.0+ now listens on
HTTPS by default, we no longer can leverage the standard Smart Proxy Facts API
which requires SSL client auth.

This series (plugin, image, proxy-proxy, proxy-image) adds new API which I
named "inventory_api" not to confuse with original "facts_api".
